### PR TITLE
Doc: Incorrect Config in Custom Config example

### DIFF
--- a/middleware/compress.md
+++ b/middleware/compress.md
@@ -21,7 +21,7 @@ func main() {
   app.Use(middleware.Compress(middleware.CompressLevelBestSpeed))
 
   // Custom Config
-  app.Use(middleware.CompressWithConfig(middleware.LoggerConfig{
+  app.Use(middleware.CompressWithConfig(middleware.CompressConfig{
     Next: func(ctx *fiber.Ctx) bool {
       return strings.HasPrefix(ctx.Path(), "/static")
     },


### PR DESCRIPTION
Under Custom Config example `CompressWithConfig(<param>)` , param should be `middleware.CompressWithConfig` instead of `middleware.LoggerConfig`